### PR TITLE
Update GSON from 2.8.9 to 2.11.0 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.peergos</groupId>
     <artifactId>nabu</artifactId>
-    <version>v0.7.8</version>
+    <version>v0.7.9</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>4.3.0</version>
+            <version>5.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/src/main/java/org/peergos/net/APIHandler.java
+++ b/src/main/java/org/peergos/net/APIHandler.java
@@ -19,7 +19,7 @@ import java.util.stream.*;
 
 public class APIHandler extends Handler {
     public static final String API_URL = "/api/v0/";
-    public static final Version CURRENT_VERSION = Version.parse("0.7.8");
+    public static final Version CURRENT_VERSION = Version.parse("0.7.9");
     private static final Logger LOG = Logging.LOG();
 
     private static final boolean LOGGING = true;


### PR DESCRIPTION
After spring-boot version update, Fruzhin stopped working because of the ```gson``` version in the ```nabu``` project. The ```jedis``` dependency has as sub-dependency ```gson```, so I updated ```jedis``` from 4.3.0 to 5.2.0, increasing indirectly the ```gson``` version to 2.11.0.